### PR TITLE
Added undo-tree

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -47,3 +47,5 @@ flycheck_*.el
 # network security
 /network-security.data
 
+# undo-tree
+*.~undo-tree~


### PR DESCRIPTION
Added undo-tree, which is a popular package for undoing changes made to a file. It leaves hidden files everywhere, and can litter up a repository if not ignored. 

I have to add `*.~undo-tree~` to every `.gitignore` file in every repository I am working in. As you can guess, this gets very tedious.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
